### PR TITLE
Add support for unix-style paths in the output when running on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,55 @@ jobs:
           - windows-latest
           - windows-2019
           - windows-2022
+        conf-file-text: [""]
+        output-unix-paths: [""]
+        include:
+          - os: ubuntu-latest
+            conf-file-text: "custom-conf"
+          - os: macos-latest
+            conf-file-text: "custom-conf"
+          - os: windows-latest
+            conf-file-text: "custom-conf"
+          - os: windows-latest
+            output-unix-paths: "unix-path"
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Override default nginx configuration with a custom one
+        id: set-conf
+        if: ${{ matrix.conf-file-text == 'custom-conf' }}
+        run: |
+          # Create multiline var
+          CONFIG="\
+          worker_processes 1;
+          events {
+              worker_connections 512;
+          }
+          http {
+              include mime.types;
+              default_type application/octet-stream;
+              sendfile on;
+              keepalive_timeout 65;
+              server {
+                  listen 8001;
+                  server_name localhost;
+                  location / {
+                      root html;
+                      index index.html index.htm;
+                  }
+              }
+          }"
+          
+          printf "conf_file_text<<EOF\n%s\nEOF" "${CONFIG}" >> "$GITHUB_OUTPUT"
 
       - name: Run setup-nginx
         uses: ./
         id: nginx
         with:
           port: "8011"
+          conf-file-text: "${{ steps.set-conf.outputs.conf_file_text }}"
+          output-unix-paths: "${{ matrix.output-unix-paths }}"
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ steps:
 
 #### Input parameters
 
-| Param          | Description                                                                 | Default |
-|----------------|-----------------------------------------------------------------------------|---------|
-| port           | The port number to use for the NGINX service, unless conf-file-text is set. | 8080    |
-| conf-file-text | Optional content of the nginx.conf file, overrides the default one          |         |
+| Param             | Description                                                                                                                           | Default |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------|
+| port              | The port number to use for the NGINX service, unless conf-file-text is set.                                                           | 8080    |
+| conf-file-text    | Optional content of the nginx.conf file, overrides the default one                                                                    |         |
+| output-unix-paths | If set to a non-empty value, will use Unix paths in the output. This is only relevant on Windows runners, ignored on other platforms. |         |
 
 #### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,28 +13,32 @@ inputs:
     description: The text of the entire configuration file to use for NGINX. This will ignore some other inputs.
     default: ""
     required: false
+  output-unix-paths:
+    description: If set to a non-empty value, will use Unix paths in the output. This is only relevant on Windows runners, ignored on other platforms.
+    default: ""
+    required: false
 outputs:
   bin:
     description: The path to the NGINX binary.
-    value: ${{ steps.detect_config.outputs.nginx_bin }}
+    value: ${{ steps.results.outputs.nginx_bin }}
   conf-path:
     description: The path to the NGINX configuration file.
-    value: ${{ steps.detect_config.outputs.conf_file }}
+    value: ${{ steps.results.outputs.conf_file }}
   html-dir:
     description: Default directory NGINX service uses as the root. This can be overridden by conf-file-text.
-    value: ${{ steps.detect_config.outputs.html_dir }}
+    value: ${{ steps.results.outputs.html_dir }}
   pid:
     description: The process ID of the NGINX service.
-    value: ${{ steps.detect_status.outputs.pid }}
+    value: ${{ steps.results.outputs.pid }}
   port:
     description: The port number used by the NGINX service.
-    value: ${{ steps.detect_status.outputs.port }}
+    value: ${{ steps.results.outputs.port }}
   access-log:
     description: The path to the NGINX access log file, unless conf-file-text is provided.
-    value: ${{ steps.detect_config.outputs.access_log }}
+    value: ${{ steps.results.outputs.access_log }}
   error-log:
     description: The path to the NGINX error log file, unless conf-file-text is provided.
-    value: ${{ steps.detect_config.outputs.error_log }}
+    value: ${{ steps.results.outputs.error_log }}
 runs:
   using: composite
   steps:
@@ -257,7 +261,7 @@ runs:
         Get-Content -Path $env:GITHUB_OUTPUT
 
     - name: Output NGINX info
-      id: detect_status
+      id: results
       shell: bash
       run: |
         echo "NGINX service was started for ${{ runner.os }} ${{ runner.arch }} on ${{ runner.name }}"
@@ -273,4 +277,21 @@ runs:
         else
             exit 1
         fi
+        
+        # if windows and output-unix-paths is set, convert paths to Unix style
+        if [[ '${{ runner.os }}' == 'Windows' && '${{ inputs.output-unix-paths }}' != '' ]]; then
+            echo "Converting Windows paths to Unix style"
+            echo "nginx_bin=$(cygpath -u '${{ steps.detect_config.outputs.nginx_bin }}')" >> $GITHUB_OUTPUT
+            echo "conf_file=$(cygpath -u '${{ steps.detect_config.outputs.conf_file }}')" >> $GITHUB_OUTPUT
+            echo "html_dir=$(cygpath -u '${{ steps.detect_config.outputs.html_dir }}')" >> $GITHUB_OUTPUT
+            echo "access_log=$(cygpath -u '${{ steps.detect_config.outputs.access_log }}')" >> $GITHUB_OUTPUT
+            echo "error_log=$(cygpath -u '${{ steps.detect_config.outputs.error_log }}')" >> $GITHUB_OUTPUT
+        else
+            echo 'nginx_bin=${{ steps.detect_config.outputs.nginx_bin }}' >> $GITHUB_OUTPUT
+            echo 'conf_file=${{ steps.detect_config.outputs.conf_file }}' >> $GITHUB_OUTPUT
+            echo 'html_dir=${{ steps.detect_config.outputs.html_dir }}' >> $GITHUB_OUTPUT
+            echo 'access_log=${{ steps.detect_config.outputs.access_log }}' >> $GITHUB_OUTPUT
+            echo 'error_log=${{ steps.detect_config.outputs.error_log }}' >> $GITHUB_OUTPUT
+        fi
+
         cat $GITHUB_OUTPUT


### PR DESCRIPTION
If `output-unix-paths` param is set to a non-empty value, will use Unix-style paths with forward slashes in the output. This is only relevant on Windows runners, ignored on other platforms.